### PR TITLE
Add support for unlimited products

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,7 +11,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
     let allProducts = []
 
-    const getMoreProducts = function (currentCursor) {
+    const getMoreProducts = async function (currentCursor) {
         const productsCache = await graphql(`
             query getAllProducts($previousProduct: String!) {
                 shopify {
@@ -40,7 +40,7 @@ exports.createPages = async ({ graphql, actions }) => {
         allProducts = allProducts.concat(productsCache.data.shopify.shop.products.edges)
 
         if (productsCache.data.shopify.shop.products.pageInfo.hasNextPage) {
-            getMoreProducts(currentCursor = productsCache.data.shopify.shop.products.edges[productsCache.data.shopify.shop.products.edges.length - 1].cursor)
+            await getMoreProducts(currentCursor = productsCache.data.shopify.shop.products.edges[productsCache.data.shopify.shop.products.edges.length - 1].cursor)
         }
     }
 
@@ -69,7 +69,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
     // if there's more products, grab next 250 products
     if (productsCache.data.shopify.shop.products.pageInfo.hasNextPage) {
-        //getMoreProducts(currentCursor = productsCache.data.shopify.shop.products.edges[productsCache.data.shopify.shop.products.edges.length - 1].cursor)
+        await getMoreProducts(currentCursor = productsCache.data.shopify.shop.products.edges[productsCache.data.shopify.shop.products.edges.length - 1].cursor)
     }
 
     allProducts.forEach(product => {

--- a/src/pages/products.js
+++ b/src/pages/products.js
@@ -32,6 +32,10 @@ query productsQuery {
                         handle
                     }
                 }
+                pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                }
             }
         }
     }


### PR DESCRIPTION
Working on adding the necessary logic to support >250 products since we can only query for 250 products per products() query.

Also made the 250 a variable. Will need to make it an env/settings variable so it can be used site-wide in-case Shopify ever changes this value.