### PR TITLE
Add variant selectors and update state

### DIFF
--- a/src/components/VariantSelector.js
+++ b/src/components/VariantSelector.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+class VariantSelector extends React.Component {
+    render() {
+        return (
+            <div>
+                <label onChange={null}>
+                    {this.props.option.name}
+                    <select
+                        className="Product__option"
+                        name={this.props.option.name}
+                        key={this.props.option.name}
+                        onChange={this.props.handleOptionChange}
+                    >
+                        {this.props.option.values.map((value) => {
+                            return (
+                                <option value={value} key={`${this.props.option.name}-${value}`}>{`${value}`}</option>
+                            )
+                        })}
+                    </select>
+                </label>
+            </div>
+        );
+    }
+}
+
+export default VariantSelector;

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -39,15 +39,15 @@ class Product extends React.Component {
         selectedOptions[target.name] = target.value;
 
         const selectedVariant = variants.findIndex(variant => {
-            let foundVariant = false;
+            let hasFoundVariant = false;
 
             variant.node.selectedOptions.forEach(selectedOption => {
                 if (selectedOptions[selectedOption.name] === selectedOption.value.valueOf()) {
-                    foundVariant = true;
+                    hasFoundVariant = true;
                 }
             });
 
-            return foundVariant;
+            return hasFoundVariant;
         });
 
         if (selectedVariant < 0) {

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -1,20 +1,18 @@
 import React from "react";
 import { StaticQuery, graphql, Link } from "gatsby"
+import Img from "gatsby-image"
 import gql from "graphql-tag"
 import { Query } from "react-apollo"
+import VariantSelector from "../components/VariantSelector"
 
 const GET_PRODUCT = gql`
 query($handle: String!) {
     shop {
-        products(first:1, query: $handle) {
-            edges {
-                node {
-                    variants(first: 1) {
-                        edges {
-                            node {
-                                availableForSale
-                            }
-                        }
+        productByHandle(handle: $handle) {
+            variants(first: 1) {
+                edges {
+                    node {
+                        availableForSale
                     }
                 }
             }
@@ -24,8 +22,66 @@ query($handle: String!) {
 `
 
 class Product extends React.Component {
+    state = { };
+
+    componentWillMount() {
+        this.props.data.shopify.shop.productByHandle.options.forEach((selector) => {
+            this.setState({
+                selectedOptions: { [selector.name]: selector.values[0] }
+            });
+        });
+    }
+
+    handleOptionChange = (event) => {
+        const target = event.target
+        const variants = this.props.data.shopify.shop.productByHandle.variants.edges;
+        let selectedOptions = this.state.selectedOptions;
+        selectedOptions[target.name] = target.value;
+
+        const selectedVariant = variants.findIndex(variant => {
+            let foundVariant = false;
+
+            variant.node.selectedOptions.forEach(selectedOption => {
+                if (selectedOptions[selectedOption.name] === selectedOption.value.valueOf()) {
+                    foundVariant = true;
+                }
+            });
+
+            return foundVariant;
+        });
+
+        if (selectedVariant < 0) {
+            return;
+        }
+
+        this.setState({
+            selectedVariant: variants[selectedVariant].node,
+            selectedVariantImage: variants[selectedVariant].node.image && variants[selectedVariant].node.image.originalSrc
+        });
+    }
+
+    handleQuantityChange = (event) => {
+        this.setState({
+            selectedVariantQuantity: event.target.value
+        });
+    }
+
     render() {
         const product = this.props.data.shopify.shop.productByHandle
+
+        let variant = this.state.selectedVariant || product.variants.edges[0].node
+        let variantImage = this.state.selectedVariantImage || product.images.edges[0].node.src
+        let variantQuantity = this.state.selectedVariantQuantity || 1
+
+        let variantSelectors = product.options.map((option) => {
+            return (
+                <VariantSelector
+                    handleOptionChange={this.handleOptionChange}
+                    key={option.id.toString()}
+                    option={option}
+                />
+            );
+        });
 
         return (
             <>
@@ -41,6 +97,12 @@ class Product extends React.Component {
                         }}
                     >
                         {product.images && product.images.edges.map((image, i) => {
+                            // return (
+                            //     <Img
+                            //         key={i}
+                            //         fixed={image.childImageSharp.fixed}
+                            //     />
+                            // )
                             return <img key={i} src={image.node.originalSrc} alt="" />
                         })}
                     </div>
@@ -51,6 +113,7 @@ class Product extends React.Component {
                         }}
                     >
                         <h1>{product.title}</h1>
+                        <div>${variant.price}</div>
                         <p>{product.description}</p>
                         <Query
                         query={GET_PRODUCT}
@@ -62,15 +125,18 @@ class Product extends React.Component {
 
                                 return (
                                     <>
-                                        <h3>Stock Status: {data && data.shop.products && data.shop.products.edges[0].node.variants && data.shop.products.edges[0].node.variants.edges[0].node.availableForSale.toString()}</h3>
+                                        <h3>Stock Status: {data && data.shop.productByHandle && data.shop.productByHandle.variants && data.shop.productByHandle.variants.edges[0].node.availableForSale.toString()}</h3>
                                     </>
                                 )
                             }}
                         </Query>
-                        <label>
-                            Quantity
-                            <input min="1" type="number" defaultValue="1"></input>
-                        </label>
+                        {variantSelectors}
+                        <div>
+                            <label onChange={null}>
+                                Quantity
+                                <input min="1" type="number" defaultValue={variantQuantity} onChange={this.handleQuantityChange}></input>
+                            </label>
+                        </div>
                         <button type="button">Buy Now</button>
                     </div>
                 </div>
@@ -89,10 +155,32 @@ query($handle: String!) {
                 title
                 description
                 handle
+                options {
+                    id
+                    name
+                    values
+                }
                 images(first: 250) {
                     edges {
                         node {
                             originalSrc
+                        }
+                    }
+                }
+                variants(first: 100) {
+                    edges {
+                        node {
+                            price
+                            compareAtPrice
+                            sku
+                            availableForSale
+                            image {
+                                originalSrc
+                            }
+                            selectedOptions {
+                                name
+                                value
+                            }
                         }
                     }
                 }

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { StaticQuery, graphql, Link } from "gatsby"
-import Img from "gatsby-image"
 import gql from "graphql-tag"
 import { Query } from "react-apollo"
 import VariantSelector from "../components/VariantSelector"


### PR DESCRIPTION
Lots more work needs to be done here:
- Add option to show as radio buttons (boxes) instead of a select
- Auto render color as hexcolor?
- Look into potential load perf issue. Selecting select has lag

Most of this code was ripped from Shopify graphql example: https://github.com/Shopify/storefront-api-examples/tree/master/react-graphql-client

<img width="372" alt="screen shot 2018-09-25 at 11 02 09 pm" src="https://user-images.githubusercontent.com/3484527/46054842-0bbacc00-c117-11e8-8539-1063c375c4e1.png">
