### PR TITLE
Feature/collections and product list

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,6 +9,9 @@ const path = require('path')
 exports.createPages = async ({ graphql, actions }) => {
     const { createPage } = actions
 
+    /**********************
+        PRODUCTS
+    ***********************/
     let allProducts = []
     const productLimitPerQuery = 250;
 
@@ -78,7 +81,7 @@ exports.createPages = async ({ graphql, actions }) => {
         await getMoreProducts(currentCursor = productsCache.data.shopify.shop.products.edges[productsCache.data.shopify.shop.products.edges.length - 1].cursor)
     }
 
-    allProducts.forEach(product => {
+    allProducts && allProducts.forEach(product => {
         createPage({
             path: `/products/${product.node.handle}`,
             component: path.resolve('./src/templates/product.js'),
@@ -88,26 +91,32 @@ exports.createPages = async ({ graphql, actions }) => {
         })
     })
 
-//     const collections = await graphql(`
-//     {
-//       allShopifyCollection {
-//         edges {
-//           node {
-//             id
-//             handle
-//           }
-//         }
-//       }
-//     }
-//   `)
+    /**********************
+        COLLECTIONS
+    ***********************/
+    const allCollections = await graphql(`
+    {
+        shopify {
+            shop {
+                collections(first: 250) {
+                    edges {
+                        node {
+                            handle
+                        }
+                    }
+                }
+            }
+        }
+    }
+  `)
 
-//     collections.data.allShopifyCollection.edges.forEach(edge => {
-//         createPage({
-//             path: `/collections/${edge.node.handle}`,
-//             component: path.resolve('./src/templates/collection.js'),
-//             context: {
-//                 id: edge.node.id,
-//             },
-//         })
-//     })
+    allCollections && allCollections.data.shopify.shop.collections.edges.forEach(edge => {
+        createPage({
+            path: `/collections/${edge.node.handle}`,
+            component: path.resolve('./src/templates/collection.js'),
+            context: {
+                handle: edge.node.handle,
+            },
+        })
+    })
 }

--- a/src/components/ProductBox.js
+++ b/src/components/ProductBox.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Link } from "gatsby"
+
+class ProductBox extends React.Component {
+    render() {
+        const {
+            handle,
+            title,
+            images,
+            priceRange: { minVariantPrice: { currencyCode, amount } }
+        } = this.props.product
+
+        const minPrice = new Intl.NumberFormat('en', { style: 'currency', currency: currencyCode }).format(amount)
+
+        return (
+            <li>
+                <Link to={`/products/${handle}`}>
+                    {images.edges.length &&
+                        <img src={images.edges[0].node.originalSrc}
+                            alt={images.edges[0].node.altText}
+                            style={{
+                                maxWidth: '275px',
+                            }}
+                        />
+                    }
+                    {/* images.edges.length && images.edges.length > 1 &&
+                        <img src={images.edges[1].node.originalSrc}
+                            alt={images.edges[1].node.altText}
+                            style={{
+                                maxWidth: '275px',
+                            }}
+                        /> */
+                    }
+                    <h3>{title}</h3>
+                    <div>{`From ${minPrice}`}</div>
+                </Link>
+            </li>
+        )
+    }
+}
+
+export default ProductBox

--- a/src/components/ProductList.js
+++ b/src/components/ProductList.js
@@ -9,7 +9,13 @@ class ProductList extends React.Component {
 
         return (
             <>
-                <ul>
+                <ul style={{
+                        display: 'grid',
+                        gridTemplateColumns: '1fr 1fr 1fr',
+                        gridGap: '10px',
+                        listStyle: 'none',
+                    }}
+                >
                     {productList}
                 </ul>
             </>

--- a/src/components/ProductList.js
+++ b/src/components/ProductList.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import ProductBox from './ProductBox'
+
+class ProductList extends React.Component {
+    render() {
+        let productList = this.props.products.edges.map(({ node }) =>
+            (<ProductBox key={node.id.toString()} product={node} />)
+        )
+
+        return (
+            <>
+                <ul>
+                    {productList}
+                </ul>
+            </>
+        )
+    }
+}
+
+export default ProductList

--- a/src/pages/products.js
+++ b/src/pages/products.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { graphql, Link } from 'gatsby'
-
+import ProductList from '../components/ProductList'
 class Products extends React.Component {
     render() {
         const products = this.props.data.shopify.shop.products
@@ -8,12 +8,11 @@ class Products extends React.Component {
         return (
             <div>
                 <h1>All Products</h1>
-                <ul>
-                    {products.edges.map((productEdge, i) => {
-                        const product = productEdge.node
-                        return <li key={i}><Link to={`/products/${product.handle}`}>{product.title}</Link></li>
-                    })}
-                </ul>
+                <ProductList products={products}
+                    style={{
+                        display: 'grid',
+                    }}
+                />
             </div>
         )
     }
@@ -28,8 +27,23 @@ query productsQuery {
             products(first: 20) {
                 edges {
                     node {
-                        title
+                        id
                         handle
+                        title
+                        priceRange {
+                            minVariantPrice {
+                                currencyCode
+                                amount
+                            }
+                        }
+                        images(first: 2) {
+                            edges {
+                                node {
+                                    originalSrc
+                                    altText
+                                }
+                            }
+                        }
                     }
                 }
                 pageInfo {

--- a/src/templates/collection.js
+++ b/src/templates/collection.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { graphql } from "gatsby"
+import ProductList from '../components/ProductList'
+
+class Collection extends React.Component {
+    state = { }
+
+    render() {
+        const { title, description, products } = this.props.data.shopify.shop.collectionByHandle
+
+        return (
+            <>
+                <h1>{title}</h1>
+                <div>{description}</div>
+                <ProductList products={products} />
+            </>
+        )
+    }
+}
+
+export default Collection
+
+export const query = graphql`
+query ($handle: String!) {
+    shopify {
+        shop {
+            collectionByHandle(handle: $handle) {
+                handle
+                title
+                description
+                image {
+                    originalSrc
+                    altText
+                }
+                products(first: 20) {
+                    edges {
+                        node {
+                            id
+                            handle
+                            title
+                            priceRange {
+                                minVariantPrice {
+                                    currencyCode
+                                    amount
+                                }
+                            }
+                            images(first: 2) {
+                                edges {
+                                    node {
+                                        originalSrc
+                                        altText
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+`;

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -102,7 +102,7 @@ class Product extends React.Component {
                             //         fixed={image.childImageSharp.fixed}
                             //     />
                             // )
-                            return <img key={i} src={image.node.originalSrc} alt="" />
+                            return <img key={i} src={image.node.originalSrc} alt={image.node.altText} />
                         })}
                     </div>
                     <div
@@ -163,6 +163,7 @@ query($handle: String!) {
                     edges {
                         node {
                             originalSrc
+                            altText
                         }
                     }
                 }
@@ -175,6 +176,7 @@ query($handle: String!) {
                             availableForSale
                             image {
                                 originalSrc
+                                altText
                             }
                             selectedOptions {
                                 name


### PR DESCRIPTION
Beginning logic for collections pages. Super basic but starting the skeleton:
- Gatsby Node logic to create (atm, first 250 collections)
  - will need to adjust to do ALL collections for large stores
-  Created Collection template
- Created ProductBox component
- Created ProductList component
  - should be useful for all instances of product boxes (related products, upsell, xsell, collections, featured products, etc.)

### TODO
- Add pagination (Only first 20 products atm. We need to add collection pages for ALL products)
  - In the future, for stores with hundreds and thousands of products in a collection, we may want to offload loading those products to Apollo? Depending on build times
- I'd like to add some Jest/Enzyme test cases for the new components going forward. Would be easier to test for regressions. 
- Also I need to add StoryBook so I can begin to spin up a basic style guide of reusable components...