### PR TITLE
addtocart checkout mutation

### DIFF
--- a/src/components/AddToCart.js
+++ b/src/components/AddToCart.js
@@ -38,23 +38,28 @@ class AddToCart extends React.Component {
                         }
                     }
                 }>
-                    {(addToCart) => (
-                        <button
-                            type="button"
-                            onClick={e => {
-                                e.preventDefault()
-                                addToCart({
-                                    variables: {
-                                        input: {
-                                            lineItems: [
-                                                { quantity: parseInt(this.props.quantity), variantId: this.props.variantId },
-                                            ]
+                    {(addToCart, {loading}) => {
+                        if (loading) return <button type="button" disabled="disabled">Adding to Cart</button>
+
+                        return (
+                            <button
+                                type="button"
+                                onClick={e => {
+                                    e.preventDefault()
+                                    addToCart({
+                                        variables: {
+                                            input: {
+                                                lineItems: [
+                                                    { quantity: parseInt(this.props.quantity), variantId: this.props.variantId },
+                                                ]
+                                            }
                                         }
-                                    }
-                                })
-                            }}
-                        >Buy Now</button>
-                )}
+                                    })
+                                }}
+                            >Buy Now</button>
+                        )
+                    }
+                }
                 </Mutation>
             </>
         )

--- a/src/components/AddToCart.js
+++ b/src/components/AddToCart.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { Mutation } from 'react-apollo'
+
+const ADD_TO_CART = gql`
+    mutation AddToCart ($input: CheckoutCreateInput!) {
+        checkoutCreate(input: $input) {
+            userErrors {
+                message
+                field
+            }
+            checkout {
+                id
+                webUrl
+                lineItems(first: 5) {
+                    edges {
+                        node {
+                            title
+                            quantity
+                        }
+                    }
+                }
+            }
+        }
+    }
+`
+
+class AddToCart extends React.Component {
+    render() {
+        return (
+            <>
+                <Mutation
+                    mutation={ADD_TO_CART}
+                    onError={this.error}
+                    onCompleted={data => {
+                        if (data.checkoutCreate.checkout.webUrl !== undefined) {
+                            window.location = data.checkoutCreate.checkout.webUrl
+                        }
+                    }
+                }>
+                    {(addToCart) => (
+                        <button
+                            type="button"
+                            onClick={e => {
+                                e.preventDefault()
+                                addToCart({
+                                    variables: {
+                                        input: {
+                                            lineItems: [
+                                                { quantity: parseInt(this.props.quantity), variantId: this.props.variantId },
+                                            ]
+                                        }
+                                    }
+                                })
+                            }}
+                        >Buy Now</button>
+                )}
+                </Mutation>
+            </>
+        )
+    }
+}
+
+export default AddToCart

--- a/src/templates/collection.js
+++ b/src/templates/collection.js
@@ -6,11 +6,12 @@ class Collection extends React.Component {
     state = { }
 
     render() {
-        const { title, description, products } = this.props.data.shopify.shop.collectionByHandle
+        const { title, description, image, products } = this.props.data.shopify.shop.collectionByHandle
 
         return (
             <>
                 <h1>{title}</h1>
+                {image && <img src={image.originalSrc} alt={image.altText} />}
                 <div>{description}</div>
                 <ProductList products={products} />
             </>

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -1,8 +1,9 @@
 import React from "react";
-import { StaticQuery, graphql, Link } from "gatsby"
+import { graphql, Link } from "gatsby"
 import gql from "graphql-tag"
 import { Query } from "react-apollo"
 import VariantSelector from "../components/VariantSelector"
+import AddToCart from "../components/AddToCart"
 
 const GET_PRODUCT = gql`
 query($handle: String!) {
@@ -21,7 +22,7 @@ query($handle: String!) {
 `
 
 class Product extends React.Component {
-    state = { };
+    state = { }
 
     componentWillMount() {
         this.props.data.shopify.shop.productByHandle.options.forEach((selector) => {
@@ -72,6 +73,8 @@ class Product extends React.Component {
         let variantImage = this.state.selectedVariantImage || product.images.edges[0].node.src
         let variantQuantity = this.state.selectedVariantQuantity || 1
 
+        const price = new Intl.NumberFormat('en', { style: 'currency', currency: product.priceRange.minVariantPrice.currencyCode }).format(variant.price)
+
         let variantSelectors = product.options.map((option) => {
             return (
                 <VariantSelector
@@ -112,7 +115,7 @@ class Product extends React.Component {
                         }}
                     >
                         <h1>{product.title}</h1>
-                        <div>${variant.price}</div>
+                        <div>{price}</div>
                         <p>{product.description}</p>
                         <Query
                         query={GET_PRODUCT}
@@ -136,7 +139,7 @@ class Product extends React.Component {
                                 <input min="1" type="number" defaultValue={variantQuantity} onChange={this.handleQuantityChange}></input>
                             </label>
                         </div>
-                        <button type="button">Buy Now</button>
+                        <AddToCart variantId={variant.id} quantity={variantQuantity} />
                     </div>
                 </div>
             </>
@@ -154,6 +157,12 @@ query($handle: String!) {
                 title
                 description
                 handle
+                priceRange {
+                    minVariantPrice {
+                        currencyCode
+                        amount
+                    }
+                }
                 options {
                     id
                     name
@@ -170,6 +179,7 @@ query($handle: String!) {
                 variants(first: 100) {
                     edges {
                         node {
+                            id
                             price
                             compareAtPrice
                             sku


### PR DESCRIPTION
Wanted to get an example mutation using the Apollo client plugin. This actually will add the variantID meaning, variant selections + quantity all work. 😄 

Just need to refactor into initial checkout instance mutation, add line item mutation, and then go to cart page. For another day...