### PR TITLE
Auth Wrapper Refactoring

### DIFF
--- a/src/components/account/AuthenticationWrapper.js
+++ b/src/components/account/AuthenticationWrapper.js
@@ -1,26 +1,24 @@
 import React from 'react'
-import { replace } from 'gatsby'
 import ContextConsumer from '../../layouts/context'
+import PropTypes from 'prop-types';
 
 class AuthenticationWrapper extends React.Component {
     render() {
         return (
             <ContextConsumer>
                 {({ data }) => {
-                    return (data.customerAccessToken &&
-                        data.customerAccessToken.expiresAt &&
-                        data.customerAccessToken.expiresAt > new Date().toISOString()) ?
-                        (!this.props.true && this.props.navigate && typeof window !== `undefined`) ?
-                            replace(this.props.navigate) :
-                            this.props.true
-                        :
-                        (!this.props.false && this.props.navigate && typeof window !== `undefined`) ?
-                            replace(this.props.navigate):
-                            this.props.false
+                    const isAuthenticated = data.customerAccessToken && data.customerAccessToken.expiresAt && data.customerAccessToken.expiresAt > new Date().toISOString() ? true : false
+                    return (this.props.children({
+                            isAuthenticated,
+                        }))
                 }}
             </ContextConsumer>
         )
     }
+}
+
+AuthenticationWrapper.propTypes = {
+    children: PropTypes.func.isRequired,
 }
 
 export default AuthenticationWrapper

--- a/src/components/account/GuestLayout.js
+++ b/src/components/account/GuestLayout.js
@@ -9,7 +9,7 @@ class GuestLayout extends React.Component {
             <AuthenticationWrapper>
                 {({ isAuthenticated }) => (
                     (isAuthenticated)
-                        ? replace(`/account`)
+                        ? (typeof window !== 'undefined') ? replace(`/account`) : null
                         : this.props.children
                 )}
             </AuthenticationWrapper>

--- a/src/components/account/GuestLayout.js
+++ b/src/components/account/GuestLayout.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import AuthenticationWrapper from './AuthenticationWrapper'
+import { replace } from 'gatsby'
+import PropTypes from 'prop-types';
+
+class GuestLayout extends React.Component {
+    render() {
+        return (
+            <AuthenticationWrapper>
+                {({ isAuthenticated }) => (
+                    (isAuthenticated)
+                        ? replace(`/account`)
+                        : this.props.children
+                )}
+            </AuthenticationWrapper>
+        )
+    }
+}
+
+export default GuestLayout
+

--- a/src/components/account/layout.js
+++ b/src/components/account/layout.js
@@ -10,7 +10,7 @@ class AccountLayout extends React.Component {
                 {({ isAuthenticated }) => (
                     (isAuthenticated)
                         ? this.props.children
-                        : replace(`/account/login`)
+                        : (typeof window !== 'undefined') ? replace(`/account/login`) : null
                 )}
             </AuthenticationWrapper>
         )

--- a/src/components/account/layout.js
+++ b/src/components/account/layout.js
@@ -1,13 +1,18 @@
 import React from 'react'
 import AuthenticationWrapper from './AuthenticationWrapper'
+import { replace } from 'gatsby'
+import PropTypes from 'prop-types';
 
 class AccountLayout extends React.Component {
     render() {
         return (
-            <AuthenticationWrapper
-                navigate={`/account/login`}
-                true={this.props.children}
-            />
+            <AuthenticationWrapper>
+                {({ isAuthenticated }) => (
+                    (isAuthenticated)
+                        ? this.props.children
+                        : replace(`/account/login`)
+                )}
+            </AuthenticationWrapper>
         )
     }
 }

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -31,32 +31,32 @@ const Header = ({ siteTitle }) => (
         >
           {siteTitle}
         </Link>
-        <AuthenticationWrapper
-          false={
-            <>
-              <Link
-                to="/account/login"
-              >
-                Log In
-              </Link>
-              <Link
-                to="/account/register"
-              >
-                Sign Up
-              </Link>
-            </>
-          }
-          true={
-            <>
-              <Link
-                to="/account"
-              >
-                My Account
-              </Link>
-              <Logout />
-            </>
-          }
-        />
+        <AuthenticationWrapper>
+          {({isAuthenticated}) => {
+            return (
+            (!isAuthenticated)
+              ? <>
+                  <Link
+                    to="/account/login"
+                  >
+                    Log In
+                  </Link>
+                    <Link
+                      to="/account/register"
+                    >
+                      Sign Up
+                  </Link>
+                </>
+              : <>
+                  <Link
+                    to="/account"
+                  >
+                    My Account
+                </Link>
+                  <Logout />
+                </>
+          )}}
+        </AuthenticationWrapper>
       </h1>
     </div>
   </div>

--- a/src/pages/account/forgotpassword.js
+++ b/src/pages/account/forgotpassword.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo'
-import { Link, navigate, replace } from 'gatsby'
+import { Link, navigate } from 'gatsby'
 import ContextConsumer from '../../layouts/context'
-import AuthenticationWrapper from '../../components/account/AuthenticationWrapper'
+import GuestLayout from '../../components/account/GuestLayout'
 import PropTypes from 'prop-types';
 
 const CUSTOMER_RESET = gql`
@@ -84,13 +84,9 @@ class ForgotPassword extends React.Component {
         )
 
         return (
-            <AuthenticationWrapper>
-                {({ isAuthenticated }) => (
-                    (isAuthenticated)
-                        ? replace(`/account`)
-                        : pageContent
-                )}
-            </AuthenticationWrapper>
+            <GuestLayout>
+                {pageContent}
+            </GuestLayout>
         )
     }
 }

--- a/src/pages/account/forgotpassword.js
+++ b/src/pages/account/forgotpassword.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo'
-import { Link, navigate } from 'gatsby'
+import { Link, navigate, replace } from 'gatsby'
 import ContextConsumer from '../../layouts/context'
 import AuthenticationWrapper from '../../components/account/AuthenticationWrapper'
+import PropTypes from 'prop-types';
 
 const CUSTOMER_RESET = gql`
 mutation customerRecover($email: String!) {
@@ -83,10 +84,13 @@ class ForgotPassword extends React.Component {
         )
 
         return (
-            <AuthenticationWrapper
-                navigate={`/account`}
-                false={pageContent}
-            />
+            <AuthenticationWrapper>
+                {({ isAuthenticated }) => (
+                    (isAuthenticated)
+                        ? replace(`/account`)
+                        : pageContent
+                )}
+            </AuthenticationWrapper>
         )
     }
 }

--- a/src/pages/account/login.js
+++ b/src/pages/account/login.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo'
-import { Link, navigate } from 'gatsby'
+import { Link, navigate, replace } from 'gatsby'
 import ContextConsumer from '../../layouts/context'
 import AuthenticationWrapper from '../../components/account/AuthenticationWrapper'
 
@@ -117,10 +117,13 @@ class Login extends React.Component {
         )
 
         return (
-            <AuthenticationWrapper
-                navigate={`/account`}
-                false={pageContent}
-            />
+            <AuthenticationWrapper>
+                {({ isAuthenticated }) => (
+                    (isAuthenticated)
+                        ? replace(`/account`)
+                        : pageContent
+                )}
+            </AuthenticationWrapper>
         )
     }
 }

--- a/src/pages/account/login.js
+++ b/src/pages/account/login.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo'
-import { Link, navigate, replace } from 'gatsby'
+import { Link, navigate } from 'gatsby'
 import ContextConsumer from '../../layouts/context'
-import AuthenticationWrapper from '../../components/account/AuthenticationWrapper'
+import GuestLayout from '../../components/account/GuestLayout'
 
 const CUSTOMER_LOGIN = gql`
 mutation customerAccessTokenCreate($input: CustomerAccessTokenCreateInput!) {
@@ -117,13 +117,9 @@ class Login extends React.Component {
         )
 
         return (
-            <AuthenticationWrapper>
-                {({ isAuthenticated }) => (
-                    (isAuthenticated)
-                        ? replace(`/account`)
-                        : pageContent
-                )}
-            </AuthenticationWrapper>
+            <GuestLayout>
+                {pageContent}
+            </GuestLayout>
         )
     }
 }

--- a/src/pages/account/register.js
+++ b/src/pages/account/register.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo'
-import { Link } from 'gatsby'
+import { Link, replace } from 'gatsby'
 import AuthenticationWrapper from '../../components/account/AuthenticationWrapper'
 
 const CUSTOMER_CREATE = gql`
@@ -102,10 +102,13 @@ class Register extends React.Component {
         )
 
         return (
-            <AuthenticationWrapper
-                navigate={`/account`}
-                false={pageContent}
-            />
+            <AuthenticationWrapper>
+                {({ isAuthenticated }) => (
+                    (!isAuthenticated)
+                        ? replace(`/account`)
+                        : pageContent
+                )}
+            </AuthenticationWrapper>
         )
     }
 }

--- a/src/pages/account/register.js
+++ b/src/pages/account/register.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo'
-import { Link, replace } from 'gatsby'
-import AuthenticationWrapper from '../../components/account/AuthenticationWrapper'
+import { Link } from 'gatsby'
+import GuestLayout from '../../components/account/GuestLayout'
 
 const CUSTOMER_CREATE = gql`
 mutation customerCreate($input: CustomerCreateInput!) {
@@ -102,13 +102,9 @@ class Register extends React.Component {
         )
 
         return (
-            <AuthenticationWrapper>
-                {({ isAuthenticated }) => (
-                    (!isAuthenticated)
-                        ? replace(`/account`)
-                        : pageContent
-                )}
-            </AuthenticationWrapper>
+            <GuestLayout>
+                {pageContent}
+            </GuestLayout>
         )
     }
 }

--- a/src/pages/account/reset.js
+++ b/src/pages/account/reset.js
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo'
 import { Link, navigate, replace } from 'gatsby'
 import ContextConsumer from '../../layouts/context'
-import AuthenticationWrapper from '../../components/account/AuthenticationWrapper'
+import GuestLayout from '../../components/account/GuestLayout'
 
 const CUSTOMER_RESET = gql`
 mutation customerReset($id: ID!, $input: CustomerResetInput!) {
@@ -135,13 +135,9 @@ class ResetPassword extends React.Component {
         return (
             (!this.state.customerId || !this.state.resetToken) ?
             <p>Malformed password reset url.</p>
-            : <AuthenticationWrapper>
-                {({ isAuthenticated }) => (
-                    (!isAuthenticated)
-                        ? replace(`/account`)
-                        : pageContent
-                )}
-            </AuthenticationWrapper>
+                : <GuestLayout>
+                    {pageContent}
+                </GuestLayout>
         )
     }
 }

--- a/src/pages/account/reset.js
+++ b/src/pages/account/reset.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo'
-import { Link, navigate } from 'gatsby'
+import { Link, navigate, replace } from 'gatsby'
 import ContextConsumer from '../../layouts/context'
 import AuthenticationWrapper from '../../components/account/AuthenticationWrapper'
 
@@ -135,11 +135,13 @@ class ResetPassword extends React.Component {
         return (
             (!this.state.customerId || !this.state.resetToken) ?
             <p>Malformed password reset url.</p>
-            :
-            <AuthenticationWrapper
-                navigate={`/account`}
-                false={pageContent}
-            />
+            : <AuthenticationWrapper>
+                {({ isAuthenticated }) => (
+                    (!isAuthenticated)
+                        ? replace(`/account`)
+                        : pageContent
+                )}
+            </AuthenticationWrapper>
         )
     }
 }


### PR DESCRIPTION
Refactored the AuthenticationWrapper component to use a render prop instead of the messy prop situation that was before.

For the GuestLayout, it can honestly be folded into **AccountLayout** component and simply pass **isGuest** or **isCustomer** booleans (`<AccountLayout isGuest={true}>` or `<AccountLayout isCustomer={true}` to handle the redirect logic since they are essentially the same with only a redirect and inverse logic. For now, I'll leave as is.

**TODO**:  add missing PropTypes validation to all components.