### PR TITLE
Add netlify cache plugin to speed up builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# gatsby-starter-shopifypwa
+# Bodega Cloud
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) 
+A Gatsby Shopify starter
 
-## Shopify PWA powered by Gatsby
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
+## Bodega Cloud powered by Gatsby, Netlify, & Shopify
 
 This will be a POC Shopify PWA using the Storefront API & GatsbyJS.
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,7 @@ require('dotenv').config({
 
 module.exports = {
   siteMetadata: {
-    title: 'Shopify PWA',
+    title: 'Bodega Cloud',
   },
   plugins: [
     `gatsby-plugin-layout`,
@@ -45,12 +45,12 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: 'Shopify PWA',
-        short_name: 'ShopifyPWA',
+        name: 'Bodega Cloud',
+        short_name: 'Bodega',
         start_url: '/',
         background_color: '#50B83C',
         theme_color: '#50B83C',
-        display: 'standalone',
+        display: 'minimal-ui',
         icon: 'src/images/gatsby-icon.png', // This path is relative to the root of the site.
       },
     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -41,6 +41,7 @@ module.exports = {
       },
     },
     `gatsby-plugin-netlify-cms`,
+    `gatsby-plugin-netlify-cache`,
     {
       resolve: `gatsby-plugin-manifest`,
       options: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-starter-shopify",
-  "description": "Shopify PWA starter",
+  "description": "Bodega Cloud - A Gatsby Shopify starter",
   "version": "0.0.1",
   "author": "Gil Greenberg <gilgreenberg@gmail.com>",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "gatsby-plugin-layout": "^1.0.1",
     "gatsby-plugin-manifest": "^2.0.2",
     "gatsby-plugin-netlify": "^2.0.4",
+    "gatsby-plugin-netlify-cache": "^1.0.0",
     "gatsby-plugin-netlify-cms": "^3.0.7",
     "gatsby-plugin-offline": "^2.0.5",
     "gatsby-plugin-react-helmet": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4424,6 +4424,15 @@ fs-extra@^5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -4526,6 +4535,14 @@ gatsby-plugin-manifest@^2.0.2:
     "@babel/runtime" "^7.0.0"
     bluebird "^3.5.0"
     sharp "^0.20.2"
+
+gatsby-plugin-netlify-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-netlify-cache/-/gatsby-plugin-netlify-cache-1.0.0.tgz#729bfae35800305e14bc098b9b2c095325cd74e2"
+  integrity sha512-lNdFUrtuEfee2FaR9Eh9ZF2gUvHQEbjZa9cNUltHj045r4Ej3dI9sXearx/+3IMbwS84aE4Q2yGEu/woNUPa+g==
+  dependencies:
+    babel-runtime "^6.26.0"
+    fs-extra "^7.0.0"
 
 gatsby-plugin-netlify-cms@^3.0.7:
   version "3.0.7"


### PR DESCRIPTION
Added the Netlify cache plugin to speed up builds. Not seeing a decrease but perhaps that's due to PR branch deployments? I'll merge for now and then revert if it's indeed not helping.

Also begin to rebrand with new bodega cloud naming.