### PR TITLE
Feature/switch shopify source

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,15 +30,12 @@ module.exports = {
       },
     },
     {
-      resolve: `gatsby-source-graphql`,
+      resolve: `gatsby-source-shopify2`,
       options: {
-        typeName: 'Shopify',
-        fieldName: 'shopify',
-        url: `https://${process.env.GATSBY_SHOPIFY_SHOP_NAME}.myshopify.com/api/graphql`,
-        headers: {
-          'X-Shopify-Storefront-Access-Token': process.env.GATSBY_SHOPIFY_ACCESS_TOKEN,
-        },
-      },
+        shopName: process.env.GATSBY_SHOPIFY_SHOP_NAME,
+        accessToken: process.env.GATSBY_SHOPIFY_ACCESS_TOKEN,
+        verbose: true,
+      }
     },
     `gatsby-plugin-netlify-cms`,
     `gatsby-plugin-netlify-cache`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,76 +12,19 @@ exports.createPages = async ({ graphql, actions }) => {
     /**********************
         PRODUCTS
     ***********************/
-    let allProducts = []
-    const productLimitPerQuery = 250;
-
-    const getMoreProducts = async function (currentCursor) {
-        const productsCache = await graphql(`
-            query getAllProducts($previousProduct: String!, $limit: Int!) {
-                shopify {
-                    shop {
-                        products(first: $limit, after: $previousProduct) {
-                            edges {
-                                cursor
-                                node {
-                                    handle
-                                }
-                            }
-                            pageInfo {
-                                hasNextPage
-                            }
-                        }
-                    }
-                }
-            }
-            `,
-            {
-                "previousProduct": currentCursor,
-                "limit": productLimitPerQuery,
-            }
-        )
-
-        // add returned paginated products to all products
-        allProducts = allProducts.concat(productsCache.data.shopify.shop.products.edges)
-
-        if (productsCache.data.shopify.shop.products.pageInfo.hasNextPage) {
-            await getMoreProducts(currentCursor = productsCache.data.shopify.shop.products.edges[productsCache.data.shopify.shop.products.edges.length - 1].cursor)
-        }
-    }
-
-    const productsCache = await graphql(`
-        query getAllProducts($limit: Int!) {
-            shopify {
-                shop {
-                    products(first: $limit) {
-                        edges {
-                            cursor
-                            node {
-                                handle
-                            }
-                        }
-                        pageInfo {
-                            hasNextPage
-                        }
-                    }
+    const allProducts = await graphql(`
+    {
+        allShopifyProduct {
+            edges {
+                node {
+                    handle
                 }
             }
         }
-        `,
-        {
-            "limit": productLimitPerQuery,
-        }
-    )
-
-    // add returned paginated products to all products
-    allProducts = allProducts.concat(productsCache.data.shopify.shop.products.edges)
-
-    // if there's more products, grab next 250 products
-    if (productsCache.data.shopify.shop.products.pageInfo.hasNextPage) {
-        await getMoreProducts(currentCursor = productsCache.data.shopify.shop.products.edges[productsCache.data.shopify.shop.products.edges.length - 1].cursor)
     }
+    `)
 
-    allProducts && allProducts.forEach(product => {
+    allProducts && allProducts.data.allShopifyProduct.edges.forEach(product => {
         createPage({
             path: `/products/${product.node.handle}`,
             component: path.resolve('./src/templates/product.js'),
@@ -96,26 +39,22 @@ exports.createPages = async ({ graphql, actions }) => {
     ***********************/
     const allCollections = await graphql(`
     {
-        shopify {
-            shop {
-                collections(first: 250) {
-                    edges {
-                        node {
-                            handle
-                        }
-                    }
+        allShopifyCollection {
+            edges {
+                node {
+                    handle
                 }
             }
         }
     }
   `)
 
-    allCollections && allCollections.data.shopify.shop.collections.edges.forEach(edge => {
+    allCollections && allCollections.data.allShopifyCollection.edges.forEach(collection => {
         createPage({
-            path: `/collections/${edge.node.handle}`,
+            path: `/collections/${collection.node.handle}`,
             component: path.resolve('./src/templates/collection.js'),
             context: {
-                handle: edge.node.handle,
+                handle: collection.node.handle,
             },
         })
     })

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gatsby-plugin-offline": "^2.0.5",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-source-filesystem": "^2.0.8",
-    "gatsby-source-graphql": "^2.0.2",
+    "gatsby-source-shopify2": "^2.0.6",
     "gatsby-transformer-json": "^2.1.5",
     "graphql-tag": "^2.9.2",
     "netlify-cms": "^2.1.3",

--- a/src/components/ProductBox.js
+++ b/src/components/ProductBox.js
@@ -15,9 +15,9 @@ class ProductBox extends React.Component {
         return (
             <li>
                 <Link to={`/products/${handle}`}>
-                    {images.edges.length &&
-                        <img src={images.edges[0].node.originalSrc}
-                            alt={images.edges[0].node.altText || ''}
+                    {images.length &&
+                        <img src={images[0].originalSrc}
+                            alt={images[0].altText || ''}
                             style={{
                                 maxWidth: '275px',
                             }}

--- a/src/components/ProductBox.js
+++ b/src/components/ProductBox.js
@@ -7,15 +7,20 @@ class ProductBox extends React.Component {
             handle,
             title,
             images,
-            priceRange: { minVariantPrice: { currencyCode, amount } }
+            priceRange,
         } = this.props.product
 
-        const minPrice = new Intl.NumberFormat('en', { style: 'currency', currency: currencyCode }).format(amount)
+        let minPrice = null;
+
+        if (priceRange) {
+            const { minVariantPrice: { currencyCode, amount } } = priceRange;
+            minPrice = new Intl.NumberFormat('en', { style: 'currency', currency: currencyCode }).format(amount)
+        }
 
         return (
             <li>
                 <Link to={`/products/${handle}`}>
-                    {images.length &&
+                    {images &&
                         <img src={images[0].originalSrc}
                             alt={images[0].altText || ''}
                             style={{
@@ -23,16 +28,8 @@ class ProductBox extends React.Component {
                             }}
                         />
                     }
-                    {/* images.edges.length && images.edges.length > 1 &&
-                        <img src={images.edges[1].node.originalSrc}
-                            alt={images.edges[1].node.altText}
-                            style={{
-                                maxWidth: '275px',
-                            }}
-                        /> */
-                    }
                     <h3>{title}</h3>
-                    <div>{`From ${minPrice}`}</div>
+                    <div>{minPrice && `From ${minPrice}`}</div>
                 </Link>
             </li>
         )

--- a/src/components/ProductList.js
+++ b/src/components/ProductList.js
@@ -3,6 +3,12 @@ import ProductBox from './ProductBox'
 
 class ProductList extends React.Component {
     render() {
+        if (!this.props.products) {
+            return (
+                <p>No products found.</p>
+            )
+        }
+
         let productList = this.props.products.edges.map(({ node }) =>
             (<ProductBox key={node.id.toString()} product={node} />)
         )

--- a/src/components/ProductList.js
+++ b/src/components/ProductList.js
@@ -9,15 +9,21 @@ class ProductList extends React.Component {
             )
         }
 
-        let productList = this.props.products.edges.map(({ node }) =>
-            (<ProductBox key={node.id.toString()} product={node} />)
-        )
+        let productList = this.props.products.map((product, key) => {
+            if (product.edge) {
+                product = product.edge;
+            }
+
+            return (
+                <ProductBox key={product.id && product.id.toString() || key} product={product} />
+            )
+        })
 
         return (
             <>
                 <ul style={{
                         display: 'grid',
-                    gridTemplateColumns: 'repeat(auto-fill, minmax(275px, 1fr))',
+                        gridTemplateColumns: 'repeat(auto-fill, minmax(275px, 1fr))',
                         gridGap: '10px',
                         listStyle: 'none',
                     }}

--- a/src/pages/products.js
+++ b/src/pages/products.js
@@ -3,7 +3,7 @@ import { graphql, Link } from 'gatsby'
 import ProductList from '../components/ProductList'
 class Products extends React.Component {
     render() {
-        const products = this.props.data.shopify.shop.products
+        const products = this.props.data.allShopifyProduct
 
         return (
             <div>
@@ -21,37 +21,24 @@ class Products extends React.Component {
 export default Products
 
 export const query = graphql`
-query productsQuery {
-    shopify {
-        shop {
-            products(first: 20) {
-                edges {
-                    node {
-                        id
-                        handle
-                        title
-                        priceRange {
-                            minVariantPrice {
-                                currencyCode
-                                amount
-                            }
-                        }
-                        images(first: 2) {
-                            edges {
-                                node {
-                                    originalSrc
-                                    altText
-                                }
-                            }
+    query productsQuery {
+        allShopifyProduct {
+            edges {
+                node {
+                    id
+                    handle
+                    title
+                    priceRange {
+                        minVariantPrice {
+                            currencyCode
+                            amount
                         }
                     }
-                }
-                pageInfo {
-                    hasNextPage
-                    hasPreviousPage
+                    images {
+                        originalSrc
+                    }
                 }
             }
         }
     }
-}
 `

--- a/src/pages/products.js
+++ b/src/pages/products.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { graphql, Link } from 'gatsby'
+import { graphql } from 'gatsby'
 import ProductList from '../components/ProductList'
 class Products extends React.Component {
     render() {
-        const products = this.props.data.allShopifyProduct
+        const products = this.props.data.allShopifyProduct.edges
 
         return (
             <div>

--- a/src/templates/collection.js
+++ b/src/templates/collection.js
@@ -6,7 +6,7 @@ class Collection extends React.Component {
     state = { }
 
     render() {
-        const { title, description, image, products } = this.props.data.shopify.shop.collectionByHandle
+        const { title, description, image, products } = this.props.data.shopifyCollection
 
         return (
             <>
@@ -23,39 +23,27 @@ export default Collection
 
 export const query = graphql`
 query ($handle: String!) {
-    shopify {
-        shop {
-            collectionByHandle(handle: $handle) {
-                handle
-                title
-                description
-                image {
-                    originalSrc
-                    altText
+    shopifyCollection(handle: {eq: $handle}) {
+        handle
+        title
+        description
+        image {
+            localFile {
+                base
+            }
+        }
+        products {
+            id
+            handle
+            title
+            priceRange {
+                minVariantPrice {
+                    currencyCode
+                    amount
                 }
-                products(first: 20) {
-                    edges {
-                        node {
-                            id
-                            handle
-                            title
-                            priceRange {
-                                minVariantPrice {
-                                    currencyCode
-                                    amount
-                                }
-                            }
-                            images(first: 2) {
-                                edges {
-                                    node {
-                                        originalSrc
-                                        altText
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+            }
+            images {
+                originalSrc
             }
         }
     }

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -25,7 +25,7 @@ class Product extends React.Component {
     state = { }
 
     componentDidMount() {
-        this.props.data.shopify.shop.productByHandle.options.forEach((selector) => {
+        this.props.data.shopifyProduct.options.forEach((selector) => {
             this.setState({
                 selectedOptions: { [selector.name]: selector.values[0] }
             });
@@ -34,7 +34,7 @@ class Product extends React.Component {
 
     handleOptionChange = (event) => {
         const target = event.target
-        const variants = this.props.data.shopify.shop.productByHandle.variants.edges;
+        const variants = this.props.data.shopifyProduct.variants.edges;
         let selectedOptions = this.state.selectedOptions;
         selectedOptions[target.name] = target.value;
 
@@ -67,10 +67,10 @@ class Product extends React.Component {
     }
 
     render() {
-        const product = this.props.data.shopify.shop.productByHandle
+        const product = this.props.data.shopifyProduct
 
-        let variant = this.state.selectedVariant || product.variants.edges[0].node
-        let variantImage = this.state.selectedVariantImage || product.images.edges[0].node.src
+        let variant = this.state.selectedVariant || product.variants[0]
+        let variantImage = this.state.selectedVariantImage || product.images[0].originalSrc
         let variantQuantity = this.state.selectedVariantQuantity || 1
 
         const price = new Intl.NumberFormat('en', { style: 'currency', currency: product.priceRange.minVariantPrice.currencyCode }).format(variant.price)
@@ -98,14 +98,14 @@ class Product extends React.Component {
                             width: '50%',
                         }}
                     >
-                        {product.images && product.images.edges.map((image, i) => {
+                        {product.images && product.images.map((image, i) => {
                             // return (
                             //     <Img
                             //         key={i}
                             //         fixed={image.childImageSharp.fixed}
                             //     />
                             // )
-                            return <img key={i} src={image.node.originalSrc} alt={image.node.altText} />
+                            return <img key={i} src={image.originalSrc} alt={image.altText} />
                         })}
                     </div>
                     <div
@@ -150,53 +150,39 @@ class Product extends React.Component {
 export default Product
 
 export const query = graphql`
-query($handle: String!) {
-    shopify {
-        shop {
-            productByHandle(handle: $handle) {
-                title
-                description
-                handle
-                priceRange {
-                    minVariantPrice {
-                        currencyCode
-                        amount
-                    }
+    query($handle: String!) {
+        shopifyProduct(handle: { eq: $handle}) {
+            title
+            description
+            handle
+            priceRange {
+                minVariantPrice {
+                    currencyCode
+                    amount
                 }
-                options {
-                    id
+            }
+            options {
+                id
+                name
+                values
+            }
+            images {
+                originalSrc
+            }
+            variants {
+                id
+                price
+                compareAtPrice
+                sku
+                availableForSale
+                image {
+                    originalSrc
+                }
+                selectedOptions {
                     name
-                    values
-                }
-                images(first: 250) {
-                    edges {
-                        node {
-                            originalSrc
-                            altText
-                        }
-                    }
-                }
-                variants(first: 100) {
-                    edges {
-                        node {
-                            id
-                            price
-                            compareAtPrice
-                            sku
-                            availableForSale
-                            image {
-                                originalSrc
-                                altText
-                            }
-                            selectedOptions {
-                                name
-                                value
-                            }
-                        }
-                    }
+                    value
                 }
             }
         }
     }
-}
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,10 +811,6 @@
   version "7.0.70"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.70.tgz#688aaeb6e6d374ed016c4dc2c46de695859d6887"
 
-"@types/node@^9.4.6":
-  version "9.6.31"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.31.tgz#4d1722987f8d808b4c194dceb8c213bd92f028e5"
-
 "@types/prop-types@*":
   version "15.5.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
@@ -1289,14 +1285,6 @@ apollo-link-http@^1.5.4:
   dependencies:
     apollo-link "^1.2.3"
     apollo-link-http-common "^0.2.5"
-
-apollo-link@1.2.1:
-  version "1.2.1"
-  resolved "http://registry.npmjs.org/apollo-link/-/apollo-link-1.2.1.tgz#c120b16059f9bd93401b9f72b94d2f80f3f305d2"
-  dependencies:
-    "@types/node" "^9.4.6"
-    apollo-utilities "^1.0.0"
-    zen-observable-ts "^0.8.6"
 
 apollo-link@^1.0.0, apollo-link@^1.2.2, apollo-link@^1.2.3:
   version "1.2.3"
@@ -2687,6 +2675,11 @@ color@^3.0.0:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
+
+colors@^1.1.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+  integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
 
 colors@~1.1.2:
   version "1.1.2"
@@ -4509,6 +4502,15 @@ gatsby-link@^2.0.6:
     "@types/reach__router" "^1.0.0"
     prop-types "^15.6.1"
 
+gatsby-node-helpers@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/gatsby-node-helpers/-/gatsby-node-helpers-0.3.0.tgz#3bdca3b7902a702a5834fef280ad66d51099d57c"
+  integrity sha1-O9yjt5AqcCpYNP7ygK1m1RCZ1Xw=
+  dependencies:
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.4"
+    p-is-promise "^1.1.0"
+
 gatsby-plugin-apollo-shopify@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-apollo-shopify/-/gatsby-plugin-apollo-shopify-1.0.2.tgz#c2ac997bd263bbcf0d1282f38f3f19ac327e81bb"
@@ -4603,6 +4605,24 @@ gatsby-react-router-scroll@^2.0.1:
     scroll-behavior "^0.9.9"
     warning "^3.0.0"
 
+gatsby-source-filesystem@^1.5.39:
+  version "1.5.39"
+  resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-1.5.39.tgz#c7e49b7809632b53c827e66ff3ee0ba74ef62dd8"
+  integrity sha1-x+SbeAljK1PIJ+Zv8+4Lp072Ldg=
+  dependencies:
+    babel-cli "^6.26.0"
+    babel-runtime "^6.26.0"
+    better-queue "^3.8.7"
+    bluebird "^3.5.0"
+    chokidar "^1.7.0"
+    fs-extra "^4.0.1"
+    got "^7.1.0"
+    md5-file "^3.1.1"
+    mime "^1.3.6"
+    pretty-bytes "^4.0.2"
+    slash "^1.0.0"
+    valid-url "^1.0.9"
+
 gatsby-source-filesystem@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.0.8.tgz#0b84e2321673d3f68c43b4a3948a3819761fde84"
@@ -4622,18 +4642,18 @@ gatsby-source-filesystem@^2.0.8:
     valid-url "^1.0.9"
     xstate "^3.1.0"
 
-gatsby-source-graphql@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/gatsby-source-graphql/-/gatsby-source-graphql-2.0.2.tgz#b64c889fba93996ea5a01efbbcf6588a647e7d2f"
+gatsby-source-shopify2@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/gatsby-source-shopify2/-/gatsby-source-shopify2-2.0.6.tgz#17f7de91cf238e843f031dea872bae359374f1c1"
+  integrity sha512-bg7vGDAFJmjkAjgJPDu3HSgZIZ5btUnm1ZxfjzzTbEeGqBpAJvm+CXTNyzmHsIz1BtLFvYBab94JggTc1JryWw==
   dependencies:
-    "@babel/runtime" "^7.0.0"
-    apollo-link "1.2.1"
-    apollo-link-http "^1.5.4"
-    graphql "^0.13.2"
-    graphql-tools "^3.0.4"
-    invariant "^2.2.4"
-    node-fetch "^1.7.3"
-    uuid "^3.1.0"
+    chalk "^2.4.1"
+    gatsby-node-helpers "^0.3.0"
+    gatsby-source-filesystem "^1.5.39"
+    graphql-request "^1.6.0"
+    lodash "^4.17.4"
+    p-iteration "^1.1.7"
+    prettyjson "^1.2.1"
 
 gatsby-transformer-json@^2.1.5:
   version "2.1.5"
@@ -4978,7 +4998,7 @@ graphql-relay@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.5.tgz#d6815e6edd618e878d5d921c13fc66033ec867e2"
 
-graphql-request@^1.5.0:
+graphql-request@^1.5.0, graphql-request@^1.6.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
   dependencies:
@@ -6101,7 +6121,7 @@ json-stream-stringify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/json-stream-stringify/-/json-stream-stringify-2.0.1.tgz#8bc0e65ff94567d9010e14c27c043a951cb14939"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -6620,6 +6640,11 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
+mime@^1.3.6:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
 mime@^2.0.3, mime@^2.2.0, mime@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
@@ -7086,7 +7111,7 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
-node-fetch@^1.0.1, node-fetch@^1.7.3:
+node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
@@ -7436,6 +7461,11 @@ p-finally@^1.0.0:
 p-is-promise@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
+
+p-iteration@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/p-iteration/-/p-iteration-1.1.7.tgz#9e71d79ede244b9f52592521f4487a56b6fb50fa"
+  integrity sha512-VsYvUPjm2edbKkX4QzlASC1qB2e4Z6IE9WPaRVHKwCtobmB6vfUcU9eBOwj1k5uMNi8O6w89QfsDatO5ePSjQg==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -8067,6 +8097,14 @@ pretty-error@^2.0.2, pretty-error@^2.1.1:
   dependencies:
     renderkid "^2.0.1"
     utila "~0.4"
+
+prettyjson@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prettyjson/-/prettyjson-1.2.1.tgz#fcffab41d19cab4dfae5e575e64246619b12d289"
+  integrity sha1-/P+rQdGcq0365eV15kJGYZsS0ok=
+  dependencies:
+    colors "^1.1.2"
+    minimist "^1.2.0"
 
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
@@ -11034,7 +11072,7 @@ yurnalist@^0.2.1:
     semver "^5.1.0"
     strip-bom "^3.0.0"
 
-zen-observable-ts@^0.8.10, zen-observable-ts@^0.8.6:
+zen-observable-ts@^0.8.10:
   version "0.8.10"
   resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.10.tgz#18e2ce1c89fe026e9621fd83cc05168228fce829"
   dependencies:


### PR DESCRIPTION
Due to lack of support for image optimization as well as built in support for querying all products, collections, etc. I’ve decided to switch to a Shopify specific source plugin. There are a number of differences in how queries are structured which resulted in the great number of code changes. There’s definitely some room for refactoring some of the code to reduce dependency on query structure. 

We’re usinf ‘gatsby-source-shopify2’ instead of the official one since there are issues with the official Shopify source plugin. Switch between them should be sesmlesss down the line. 